### PR TITLE
Use slash comments in PHP files

### DIFF
--- a/server/commentSyntax.ts
+++ b/server/commentSyntax.ts
@@ -64,6 +64,7 @@ const SYNTAX_GROUPS: Array<[CommentSyntax, LanguageName[]]> = [
       'C#',
       'Scala',
       'Dart',
+      'PHP',
       'Zig',
       'JSON5',
       'JSON with Comments',
@@ -100,6 +101,7 @@ const EXTENSION_OVERRIDES: Partial<Record<string, LanguageName>> = {
   '.rs': 'Rust',
   '.ts': 'TypeScript',
   '.cls': 'TeX',
+  '.php': 'PHP',
 }
 
 const EXTENSION_SYNTAX_OVERRIDES: Partial<Record<string, CommentSyntax>> = {


### PR DESCRIPTION
Also claim that all .php files are PHP. They might technically be Hack, which [also uses slash comments](https://docs.hhvm.com/hack/source-code-fundamentals/comments/).

Related: #26