### PR TITLE
Use slash comments in Vue single-file components

### DIFF
--- a/server/commentSyntax.test.ts
+++ b/server/commentSyntax.test.ts
@@ -37,6 +37,7 @@ describe('detectLanguage', () => {
     ['foo.sh', '', 'Shell'],
     ['foo.yaml', '', 'YAML'],
     ['foo.yml', '', 'YAML'],
+    ['foo.vue', '', 'Vue'],
     // Ambiguous extensions pinned via override
     ['README.md', '', 'Markdown'],
     ['foo.h', '', 'C'],
@@ -92,6 +93,7 @@ describe('getCommentSyntax', () => {
     ['foo.yaml', '', { prefix: '#' }],
     ['foo.yml', '', { prefix: '#' }],
     ['foo.conf', '', { prefix: '#' }],
+    ['foo.vue', '', { prefix: '//' }],
     ['script.nu', '', { prefix: '#' }],
     ['Nukefile', '', { prefix: ';' }],
     ['somebin', '#!/bin/bash', { prefix: '#' }],

--- a/server/commentSyntax.ts
+++ b/server/commentSyntax.ts
@@ -71,6 +71,11 @@ const SYNTAX_GROUPS: Array<[CommentSyntax, LanguageName[]]> = [
       // JSON doesn't support comments, but the user opted in; '//' produces
       // invalid JSON that most editors still highlight recognizably.
       'JSON',
+      // Vue single-file components may contain a mix of syntaxes (HTML,
+      // JS/TS, CSS, SCSS etc). Using slashes will work in JS/TS and HTML
+      // (though will not actually be a comment in HTML), and may work in
+      // *some* CSS syntaxes, so I chose it as a compromise.
+      'Vue',
     ],
   ],
   [XML_COMMENT, ['HTML', 'XML', 'SVG', 'Markdown', 'MDX']],


### PR DESCRIPTION
This is a compromise due to the lack of parsing different types of syntax within a single file. Slashes are the "most compatible" with different syntaxes found in Vue SFCs.

See https://github.com/oxidecomputer/skepsis/issues/26#issuecomment-4340405454

Example of reviewing a Vue SFC:

<img width="1051" height="589" alt="Screenshot 2026-04-29 at 15 48 24" src="https://github.com/user-attachments/assets/425a1ef4-f8f5-4512-995b-ec2d810e6d40" />
