### PR TITLE
Better default revsets, show diff command in UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -17,6 +17,6 @@ jobs:
   license:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Check License Header
         uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       contents: write # to push the release tag
       id-token: write # required for OIDC trusted publishing
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Check whether package.json version is already published
         id: check
         run: |
@@ -83,7 +83,7 @@ jobs:
       id-token: write # required for OIDC trusted publishing
       pull-requests: write # to comment the canary version on the PR
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # works for fork PRs too; the workflow itself always runs from main
           ref: refs/pull/${{ inputs.pr-number }}/head

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ The examples use `skepsis`, the installed bin name. An `sk` alias works the
 same way.
 
 ```
-skepsis                          # review trunk()..@
+skepsis                          # review branch vs trunk, GitHub PR style
+                                 # (jj diff --from 'fork_point(trunk() | @)')
 skepsis -r @                     # review working copy only
 skepsis -r 'mybranch..@'         # review a range
 skepsis -f main -t @             # diff between two revisions
@@ -68,7 +69,8 @@ skepsis -f main -t @             # diff between two revisions
 Ranges passed with `-r` are passed through verbatim to `git diff`.
 
 ```
-skepsis                          # git diff origin/HEAD..HEAD
+skepsis                          # review branch vs origin, GitHub PR style
+                                 # (git diff origin/HEAD...HEAD)
 skepsis -f main                  # diff since main: git diff main HEAD
 skepsis -r main..my-branch       # review commits on my-branch
 skepsis -r HEAD~5..HEAD          # review the last 5 commits

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ skepsis -f main -t @             # diff between two revisions
 Ranges passed with `-r` are passed through verbatim to `git diff`.
 
 ```
-skepsis                          # review branch vs origin, GitHub PR style
-                                 # (git diff origin/HEAD...HEAD, falling back
-                                 # to origin/main, origin/master, main, master)
+skepsis                          # review branch + working tree vs origin
+                                 # (git diff --merge-base origin/HEAD; falls
+                                 # back to origin/main, origin/master, main,
+                                 # master)
 skepsis -f main                  # diff since main: git diff main HEAD
 skepsis -r main..my-branch       # review commits on my-branch
 skepsis -r HEAD~5..HEAD          # review the last 5 commits
@@ -96,7 +97,8 @@ Review comments are inserted into the source files, so they show up in your VCS
 diff and are visible to coding agents. They can be resolved (deleted) from the
 UI. Comments are only enabled when the diff includes the working copy (e.g.,
 a revset ending in `@` for jj, or an open-ended range ending at the working
-tree for git), since that's where the inserted lines land.
+tree for git), since that's where the inserted lines land. The default diff
+in both modes ends at the working copy, so comments are enabled by default.
 
 ### Marking files viewed
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Ranges passed with `-r` are passed through verbatim to `git diff`.
 
 ```
 skepsis                          # review branch vs origin, GitHub PR style
-                                 # (git diff origin/HEAD...HEAD)
+                                 # (git diff origin/HEAD...HEAD, falling back
+                                 # to origin/main, origin/master, main, master)
 skepsis -f main                  # diff since main: git diff main HEAD
 skepsis -r main..my-branch       # review commits on my-branch
 skepsis -r HEAD~5..HEAD          # review the last 5 commits

--- a/cli.ts
+++ b/cli.ts
@@ -69,8 +69,18 @@ function buildDiffSource(): DiffArgs {
       commentsEnabled = !opts.to || opts.to === '@'
       // jj defaults both --from and --to to @
       endpoints = { left: opts.from ?? '@', right: { rev: opts.to ?? '@' } }
+    } else if (!opts.revisions) {
+      // Default: GitHub-PR-style diff from the fork point of trunk and @.
+      // Same output as `-r 'trunk()..@'` for a linear branch, but still works
+      // after trunk has been merged into the branch, where jj rejects
+      // `trunk()..@` ("Cannot diff revsets with gaps in"). fork_point()
+      // requires jj >= 0.24.
+      const from = 'fork_point(trunk() | @)'
+      args.push('--from', from)
+      commentsEnabled = true
+      endpoints = { left: from, right: { rev: '@' } }
     } else {
-      const rev = opts.revisions ?? 'trunk()..@'
+      const rev = opts.revisions
       args.push('-r', rev)
       // Comments enabled if the revset's "to" side is @
       commentsEnabled = rev === '@' || rev.endsWith('..@')
@@ -101,8 +111,27 @@ function buildDiffSource(): DiffArgs {
         commentsEnabled = true
         endpoints = { left: opts.from!, right: 'workingCopy' }
       }
+    } else if (!opts.revisions) {
+      // Default: GitHub-PR-style three-dot diff, i.e. from merge-base(A, B)
+      // to B, so upstream commits the branch doesn't have don't show up as
+      // reversions (two-dot `git diff A..B` compares A and B directly).
+      args = ['origin/HEAD...HEAD']
+      commentsEnabled = false
+      // `git show 'A...B:path'` isn't valid, so resolve the merge base up
+      // front for the left endpoint. If it fails (e.g. origin/HEAD is not
+      // set), leave expansion disabled and let diff validation report it.
+      let mergeBase: string | null = null
+      try {
+        mergeBase = execFileSync('git', ['merge-base', 'origin/HEAD', 'HEAD'], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim()
+      } catch {
+        mergeBase = null
+      }
+      endpoints = mergeBase ? { left: mergeBase, right: { rev: 'HEAD' } } : null
     } else {
-      const rev = opts.revisions ?? 'origin/HEAD..HEAD'
+      const rev = opts.revisions
       // No .. means single ref, which diffs against working tree
       commentsEnabled = !rev.includes('..')
       args = [rev]

--- a/cli.ts
+++ b/cli.ts
@@ -142,15 +142,18 @@ function buildDiffSource(): DiffArgs {
         endpoints = { left: opts.from!, right: 'workingCopy' }
       }
     } else if (!opts.revisions) {
-      // Default: GitHub-PR-style three-dot diff, i.e. from merge-base(A, B)
-      // to B, so upstream commits the branch doesn't have don't show up as
-      // reversions (two-dot `git diff A..B` compares A and B directly).
+      // Default: the git translation of the jj default — diff the working
+      // tree against the fork point with trunk. `git diff --merge-base A` is
+      // equivalent to `git diff $(git merge-base A HEAD)` (git >= 2.30).
+      // Using the merge base keeps upstream commits the branch doesn't have
+      // from showing up as reversions, and ending at the working tree means
+      // review comments work out of the box.
       const base = resolveGitBase()
-      args = [`${base}...HEAD`]
-      commentsEnabled = false
-      // `git show 'A...B:path'` isn't valid, so resolve the merge base up
-      // front for the left endpoint. If it fails (e.g. unrelated histories),
-      // leave expansion disabled and let diff validation report any error.
+      args = ['--merge-base', base]
+      commentsEnabled = true
+      // `git show` has no --merge-base, so resolve the sha up front for the
+      // left endpoint. If it fails (e.g. unrelated histories), leave
+      // expansion disabled and let diff validation report any error.
       let mergeBase: string | null = null
       try {
         mergeBase = execFileSync('git', ['merge-base', base, 'HEAD'], {
@@ -160,7 +163,7 @@ function buildDiffSource(): DiffArgs {
       } catch {
         mergeBase = null
       }
-      endpoints = mergeBase ? { left: mergeBase, right: { rev: 'HEAD' } } : null
+      endpoints = mergeBase ? { left: mergeBase, right: 'workingCopy' } : null
     } else {
       const rev = opts.revisions
       // No .. means single ref, which diffs against working tree

--- a/cli.ts
+++ b/cli.ts
@@ -46,6 +46,36 @@ function detectVcs(): 'jj' | 'git' {
 
 const vcs = opts.git ? 'git' : detectVcs()
 
+/* Base rev candidates for the default git diff. origin/HEAD only exists when
+ * a clone set it (git clone does, git remote add does not), so fall back to
+ * common default-branch names, remote-tracking first — a poor man's version
+ * of what jj's trunk() does. */
+const GIT_BASE_CANDIDATES = [
+  'origin/HEAD',
+  'origin/main',
+  'origin/master',
+  'main',
+  'master',
+]
+
+function resolveGitBase(): string {
+  for (const rev of GIT_BASE_CANDIDATES) {
+    try {
+      execFileSync('git', ['rev-parse', '--verify', '--quiet', `${rev}^{commit}`], {
+        stdio: 'ignore',
+      })
+      return rev
+    } catch {
+      // try the next candidate
+    }
+  }
+  console.error(
+    `No base revision found for the default diff (tried ${GIT_BASE_CANDIDATES.join(', ')}).\n` +
+      'Specify a range explicitly with -r or -f/-t.',
+  )
+  process.exit(1)
+}
+
 /** Split an `A..B` range into its two revs. Returns null for anything that
  *  isn't a simple two-sided range with both sides non-empty. */
 function parseRange(rev: string): { left: string; right: string } | null {
@@ -115,14 +145,15 @@ function buildDiffSource(): DiffArgs {
       // Default: GitHub-PR-style three-dot diff, i.e. from merge-base(A, B)
       // to B, so upstream commits the branch doesn't have don't show up as
       // reversions (two-dot `git diff A..B` compares A and B directly).
-      args = ['origin/HEAD...HEAD']
+      const base = resolveGitBase()
+      args = [`${base}...HEAD`]
       commentsEnabled = false
       // `git show 'A...B:path'` isn't valid, so resolve the merge base up
-      // front for the left endpoint. If it fails (e.g. origin/HEAD is not
-      // set), leave expansion disabled and let diff validation report it.
+      // front for the left endpoint. If it fails (e.g. unrelated histories),
+      // leave expansion disabled and let diff validation report any error.
       let mergeBase: string | null = null
       try {
-        mergeBase = execFileSync('git', ['merge-base', 'origin/HEAD', 'HEAD'], {
+        mergeBase = execFileSync('git', ['merge-base', base, 'HEAD'], {
           encoding: 'utf8',
           stdio: ['ignore', 'pipe', 'ignore'],
         }).trim()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/skepsis",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/skepsis",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "skepsis": "dist/cli.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/skepsis",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/skepsis",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "bin": {
         "skepsis": "dist/cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/skepsis",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "repository": "github:oxidecomputer/skepsis",
   "bin": {
     "skepsis": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/skepsis",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": "github:oxidecomputer/skepsis",
   "bin": {
     "skepsis": "dist/cli.js"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -521,10 +521,12 @@ function FileHeader({
 }
 
 function ProgressBar({
+  command,
   fileHashes,
   viewed,
   onUnviewAll,
 }: {
+  command: string
   fileHashes: FileHashes
   viewed: ViewedMap
   onUnviewAll: () => void
@@ -538,6 +540,13 @@ function ProgressBar({
 
   return (
     <div className="progress-bar">
+      <code className="diff-command">{command}</code>
+      <div className="progress-track">
+        <div
+          className="progress-fill"
+          style={{ width: `${(viewedCount / total) * 100}%` }}
+        />
+      </div>
       <span>
         {viewedCount}/{total} files viewed
       </span>
@@ -553,12 +562,6 @@ function ProgressBar({
           Clear
         </button>
       </Tip>
-      <div className="progress-track">
-        <div
-          className="progress-fill"
-          style={{ width: `${(viewedCount / total) * 100}%` }}
-        />
-      </div>
     </div>
   )
 }
@@ -1507,6 +1510,7 @@ function DiffView() {
       )}
       <div className="diff-container">
         <ProgressBar
+          command={data.revset}
           fileHashes={fileHashes}
           viewed={viewed}
           onUnviewAll={() => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -449,8 +449,35 @@ body,
   color: var(--fg-muted);
 }
 
+/* The diff command behind the current view, so the range being reviewed is
+   visible without checking the terminal. Truncates first when the row runs
+   out of room; hover shows the full command. */
+.diff-command {
+  padding: 3px 6px;
+  background: var(--bg-muted);
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.progress-bar > span {
+  flex-shrink: 0;
+  white-space: nowrap;
+  color: var(--fg-dim);
+}
+
+/* Kept small and right next to the counter so it reads as viewed-progress
+   rather than something about the diff as a whole. margin-left: auto pushes
+   the whole progress group to the right end of the row. */
 .progress-track {
-  flex: 1;
+  flex: 0 0 96px;
+  margin-left: auto;
   height: 4px;
   background: var(--bg-muted);
   border-radius: 2px;
@@ -491,7 +518,7 @@ body,
    aria-disabled rather than the disabled attribute, since disabled buttons
    don't fire :hover. */
 .unview-all-button.disabled {
-  opacity: 0.4;
+  opacity: 0.6;
   cursor: default;
 }
 


### PR DESCRIPTION
- Update default revsets to better handle merge commits (jj uses `fork_point`, git behaves similarly)
- Add diff command to the top bar in the UI
- Move files viewed count and clear to the right end

<img width="986" height="344" alt="image" src="https://github.com/user-attachments/assets/3974cfda-26a7-45d1-b77c-acdf68cc2021" />
