### PR TITLE
Small fixes to new default revset logic

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -46,8 +46,9 @@ function detectVcs(): 'jj' | 'git' {
 
 const vcs = opts.git ? 'git' : detectVcs()
 
-/* Base rev candidates for the default git diff. origin/HEAD only exists when
- * a clone set it (git clone does, git remote add does not), so fall back to
+/* Base rev candidates for the default git diff. A remote's default branch
+ * (origin/HEAD) is optional — "Having a default branch for a remote is not
+ * required" (https://git-scm.com/docs/git-remote, set-head) — so fall back to
  * common default-branch names, remote-tracking first — a poor man's version
  * of what jj's trunk() does. */
 const GIT_BASE_CANDIDATES = [
@@ -58,15 +59,27 @@ const GIT_BASE_CANDIDATES = [
   'master',
 ]
 
-function resolveGitBase(): string {
-  for (const rev of GIT_BASE_CANDIDATES) {
+/** Find the trunk-ish base for the default diff, plus its merge base with
+ *  HEAD. Probing with `git merge-base` both verifies the candidate exists and
+ *  yields the fork-point sha in one step. */
+function resolveGitBase(): { base: string; mergeBase: string } {
+  for (const base of GIT_BASE_CANDIDATES) {
     try {
-      execFileSync('git', ['rev-parse', '--verify', '--quiet', `${rev}^{commit}`], {
-        stdio: 'ignore',
-      })
-      return rev
-    } catch {
-      // try the next candidate
+      const mergeBase = execFileSync('git', ['merge-base', base, 'HEAD'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).trim()
+      return { base, mergeBase }
+    } catch (error) {
+      // A missing candidate or no common ancestor means try the next one, but
+      // outside a repo or without git installed every candidate fails the
+      // same way — git's own error beats a misleading "no base revision
+      // found" that suggests -r/-f flags that would also fail.
+      const { code, stderr } = error as { code?: string; stderr?: string }
+      if (code === 'ENOENT' || stderr?.includes('not a git repository')) {
+        console.error(stderr?.trim() || (error as Error).message)
+        process.exit(1)
+      }
     }
   }
   console.error(
@@ -104,7 +117,8 @@ function buildDiffSource(): DiffArgs {
       // Same output as `-r 'trunk()..@'` for a linear branch, but still works
       // after trunk has been merged into the branch, where jj rejects
       // `trunk()..@` ("Cannot diff revsets with gaps in"). fork_point()
-      // requires jj >= 0.24.
+      // requires jj >= 0.24
+      // (https://github.com/jj-vcs/jj/releases/tag/v0.24.0).
       const from = 'fork_point(trunk() | @)'
       args.push('--from', from)
       commentsEnabled = true
@@ -129,6 +143,7 @@ function buildDiffSource(): DiffArgs {
     let args: string[]
     let commentsEnabled: boolean
     let endpoints: DiffEndpoints
+    let displayArgs: string[] | undefined
     if (opts.from || opts.to) {
       if (opts.to) {
         // Explicit --to: commit-to-commit diff, no working copy
@@ -143,27 +158,21 @@ function buildDiffSource(): DiffArgs {
       }
     } else if (!opts.revisions) {
       // Default: the git translation of the jj default — diff the working
-      // tree against the fork point with trunk. `git diff --merge-base A` is
-      // equivalent to `git diff $(git merge-base A HEAD)` (git >= 2.30).
-      // Using the merge base keeps upstream commits the branch doesn't have
-      // from showing up as reversions, and ending at the working tree means
-      // review comments work out of the box.
-      const base = resolveGitBase()
-      args = ['--merge-base', base]
+      // tree against the branch's fork point from trunk (the merge base of
+      // the resolved base and HEAD). Using the merge base keeps upstream
+      // commits the branch doesn't have from showing up as reversions, and
+      // ending at the working tree means review comments work out of the box.
+      // Diffing against the resolved sha rather than `git diff --merge-base
+      // <base>` pins the diff and hunk expansion to the same commit — they
+      // can't drift apart if the base moves while the server runs — and
+      // avoids --merge-base's hard error when there are multiple merge bases.
+      // The sha is unreadable, so show the equivalent symbolic command in the
+      // UI and log.
+      const { base, mergeBase } = resolveGitBase()
+      args = [mergeBase]
+      displayArgs = ['--merge-base', base]
       commentsEnabled = true
-      // `git show` has no --merge-base, so resolve the sha up front for the
-      // left endpoint. If it fails (e.g. unrelated histories), leave
-      // expansion disabled and let diff validation report any error.
-      let mergeBase: string | null = null
-      try {
-        mergeBase = execFileSync('git', ['merge-base', base, 'HEAD'], {
-          encoding: 'utf8',
-          stdio: ['ignore', 'pipe', 'ignore'],
-        }).trim()
-      } catch {
-        mergeBase = null
-      }
-      endpoints = mergeBase ? { left: mergeBase, right: 'workingCopy' } : null
+      endpoints = { left: mergeBase, right: 'workingCopy' }
     } else {
       const rev = opts.revisions
       // No .. means single ref, which diffs against working tree
@@ -178,7 +187,7 @@ function buildDiffSource(): DiffArgs {
         endpoints = null
       }
     }
-    return { vcs: 'git', args, commentsEnabled, files, endpoints }
+    return { vcs: 'git', args, commentsEnabled, files, endpoints, displayArgs }
   }
 }
 

--- a/cli.ts
+++ b/cli.ts
@@ -105,24 +105,20 @@ function buildDiffSource(): DiffArgs {
     const args: string[] = []
     let commentsEnabled: boolean
     let endpoints: DiffEndpoints
-    if (opts.from || opts.to) {
-      if (opts.from) args.push('--from', opts.from)
+    if (opts.from || opts.to || !opts.revisions) {
+      // With no range flags at all, --from defaults to a GitHub-PR-style diff
+      // from the fork point of trunk and @. Same output as `-r 'trunk()..@'`
+      // for a linear branch, but still works after trunk has been merged into
+      // the branch, where jj rejects `trunk()..@` ("Cannot diff revsets with
+      // gaps in"). fork_point() requires jj >= 0.24
+      // (https://github.com/jj-vcs/jj/releases/tag/v0.24.0).
+      const from = opts.from ?? (opts.to ? undefined : 'fork_point(trunk() | @)')
+      if (from) args.push('--from', from)
       if (opts.to) args.push('--to', opts.to)
       // Comments enabled if --to is @ or omitted (jj defaults --to to @)
       commentsEnabled = !opts.to || opts.to === '@'
       // jj defaults both --from and --to to @
-      endpoints = { left: opts.from ?? '@', right: { rev: opts.to ?? '@' } }
-    } else if (!opts.revisions) {
-      // Default: GitHub-PR-style diff from the fork point of trunk and @.
-      // Same output as `-r 'trunk()..@'` for a linear branch, but still works
-      // after trunk has been merged into the branch, where jj rejects
-      // `trunk()..@` ("Cannot diff revsets with gaps in"). fork_point()
-      // requires jj >= 0.24
-      // (https://github.com/jj-vcs/jj/releases/tag/v0.24.0).
-      const from = 'fork_point(trunk() | @)'
-      args.push('--from', from)
-      commentsEnabled = true
-      endpoints = { left: from, right: { rev: '@' } }
+      endpoints = { left: from ?? '@', right: { rev: opts.to ?? '@' } }
     } else {
       const rev = opts.revisions
       args.push('-r', rev)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/skepsis",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/skepsis",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "bin": {
         "skepsis": "dist/cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/skepsis",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "repository": "github:oxidecomputer/skepsis",
   "bin": {
     "skepsis": "dist/cli.js"

--- a/server/displayCommand.test.ts
+++ b/server/displayCommand.test.ts
@@ -1,0 +1,54 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { DiffArgs } from '../shared/types.ts'
+import { displayCommand } from './displayCommand.ts'
+
+const base = { commentsEnabled: true, files: [], endpoints: null }
+
+describe('displayCommand', () => {
+  it('leaves plain args unquoted', () => {
+    const src: DiffArgs = { vcs: 'git', args: ['--merge-base', 'origin/main'], ...base }
+    expect(displayCommand(src)).toBe('git diff --merge-base origin/main')
+  })
+
+  it('quotes args with shell metacharacters so the command is runnable', () => {
+    const src: DiffArgs = {
+      vcs: 'jj',
+      args: ['--from', 'fork_point(trunk() | @)'],
+      ...base,
+    }
+    expect(displayCommand(src)).toBe("jj diff --from 'fork_point(trunk() | @)'")
+  })
+
+  it('escapes single quotes inside quoted args', () => {
+    const src: DiffArgs = { vcs: 'git', args: ["it's"], ...base }
+    expect(displayCommand(src)).toBe(String.raw`git diff 'it'\''s'`)
+  })
+
+  it('prefers displayArgs over args when present', () => {
+    const src: DiffArgs = {
+      vcs: 'git',
+      args: ['0123456789abcdef0123456789abcdef01234567'],
+      displayArgs: ['--merge-base', 'origin/main'],
+      ...base,
+    }
+    expect(displayCommand(src)).toBe('git diff --merge-base origin/main')
+  })
+
+  it('quotes file paths after --', () => {
+    const src: DiffArgs = {
+      vcs: 'git',
+      args: ['main'],
+      ...base,
+      files: ['src/app.ts', 'my file.txt'],
+    }
+    expect(displayCommand(src)).toBe("git diff main -- src/app.ts 'my file.txt'")
+  })
+})

--- a/server/displayCommand.ts
+++ b/server/displayCommand.ts
@@ -1,0 +1,24 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import type { DiffArgs } from '../shared/types.ts'
+
+/** Quote an arg so the displayed command is copy-paste runnable in a shell
+ *  (revsets like `fork_point(trunk() | @)` contain metacharacters). */
+function shellQuote(arg: string): string {
+  if (/^[\w@%+=:,./^~-]+$/.test(arg)) return arg
+  return `'${arg.replaceAll("'", String.raw`'\''`)}'`
+}
+
+/** The user-facing diff command, shown in the UI and the startup log. */
+export function displayCommand(diffSource: DiffArgs): string {
+  const args = (diffSource.displayArgs ?? diffSource.args).map(shellQuote)
+  const files = diffSource.files.map(shellQuote)
+  const fileSuffix = files.length > 0 ? ` -- ${files.join(' ')}` : ''
+  return `${diffSource.vcs} diff ${args.join(' ')}${fileSuffix}`
+}

--- a/server/main.ts
+++ b/server/main.ts
@@ -14,6 +14,7 @@ import { join, relative } from 'node:path'
 import { readFile } from 'node:fs/promises'
 import type { DiffArgs } from '../shared/types.ts'
 import { getDiff, validateDiffArgs } from './diff.ts'
+import { displayCommand } from './displayCommand.ts'
 import { getFileContents } from './fileContents.ts'
 import { loadViewed, markViewed, unmarkViewed, unmarkViewedAll } from './viewed.ts'
 import { insertComment, removeComment } from './comment.ts'
@@ -46,14 +47,9 @@ export async function startServer(opts: {
   app.get('/api/diff', async (c) => {
     const { patch, fileHashes } = await getDiff(diffSource)
     const viewed = await loadViewed(cwd, fileHashes)
-    const fileSuffix =
-      diffSource.files.length > 0 ? ` -- ${diffSource.files.join(' ')}` : ''
     return c.json({
       patch,
-      revset:
-        diffSource.vcs === 'jj'
-          ? `jj diff ${diffSource.args.join(' ')}${fileSuffix}`
-          : `git diff ${diffSource.args.join(' ')}${fileSuffix}`,
+      revset: displayCommand(diffSource),
       vcs: diffSource.vcs,
       commentsEnabled: diffSource.commentsEnabled,
       expandable: diffSource.endpoints !== null,
@@ -120,9 +116,7 @@ export async function startServer(opts: {
     serve({ fetch: app.fetch, port, hostname }, (info) => {
       const assignedPort = typeof info === 'string' ? port : info.port
       console.info(
-        `skepsis on http://${hostname}:${assignedPort} (${diffSource.vcs}: ${diffSource.args.join(' ')}${
-          diffSource.files.length > 0 ? ` -- ${diffSource.files.join(' ')}` : ''
-        })`,
+        `skepsis on http://${hostname}:${assignedPort} (${displayCommand(diffSource)})`,
       )
       resolve(assignedPort)
     })

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -65,6 +65,10 @@ export type DiffArgs = ({ vcs: 'jj'; args: string[] } | { vcs: 'git'; args: stri
   commentsEnabled: boolean
   files: string[]
   endpoints: DiffEndpoints
+  /** Args to show in the UI/log command string in place of `args`, for when
+   *  the executed args (e.g., a resolved sha) are less readable than the
+   *  user-facing form. */
+  displayArgs?: string[]
 }
 
 // --- Response types (checked via satisfies on the server) ---

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -540,7 +540,10 @@ function ProgressBar({
 
   return (
     <div className="progress-bar">
-      <code className="diff-command">{command}</code>
+      {/* title gives a native tooltip when the command is ellipsized */}
+      <code className="diff-command" title={command}>
+        {command}
+      </code>
       <div className="progress-track">
         <div
           className="progress-fill"


### PR DESCRIPTION
Followups to #47 based on bot review.

- The git default now diffs against the resolved merge-base sha instead of passing `--merge-base <base>`, which re-resolved the base on every request — the diff and hunk expansion could drift apart if the base moved while the server ran, and repos with multiple merge bases failed at startup. The UI still shows the symbolic form.
- The displayed command is shell-quoted so it's runnable directly from a copy-paste (`jj diff --from 'fork_point(trunk() | @)'`), and a `title` tooltip recovers it when ellipsized.
- Running with `--git` outside a repo now prints git's own error instead of suggesting `-r`/`-f` flags that would also fail.